### PR TITLE
Global Post context

### DIFF
--- a/src/components/home/Post.jsx
+++ b/src/components/home/Post.jsx
@@ -4,9 +4,8 @@ import styled from 'styled-components';
 import { Link } from 'react-router-dom';
 
 // global contexts
-import { useAuth0 } from '@auth0/auth0-react';
 import { useUserInfo } from '../../contexts/UserContext.jsx';
-import { PostsContext } from '../../contexts/PostsContext.jsx';
+import { usePosts } from '../../contexts/PostsContext.jsx';
 import { usePlayer } from '../../contexts/player/playerContext';
 
 // components
@@ -15,13 +14,10 @@ import { Hashtag } from './Hashtag.jsx';
 import helpers from './helperFunctions.js';
 
 const Post = (props) => {
-  const { user } = useAuth0();
-  const { username, setUsername, email, setEmail, profilePic, setProfilePic } =
-    useUserInfo();
+  const { email } = useUserInfo();
+  const { isPostUpdated, setIsPostUpdated } = usePosts();
   const { SetCurrent, currentSong, songs } = usePlayer();
-  const { posts, setPosts } = React.useContext(PostsContext);
-
-  // console.log({ username, email, profilePic });
+  // const { posts, setPosts } = React.useContext(PostsContext);
 
   const handleDeletePost = (event) => {
     const postId = props.postId;
@@ -32,6 +28,9 @@ const Post = (props) => {
     // .catch((error) => {
 
     // })
+
+    // eslint-disable-next-line no-extra-boolean-cast
+    setIsPostUpdated(!!!isPostUpdated);
   };
 
   return (
@@ -49,9 +48,11 @@ const Post = (props) => {
           </PostUsernameAndTime>
           <Link to="/studio">
             {/* TODO: implement trash functionality if post is by user */}
-            {/* {(user.isAuthenticated && (props.userEmail === user.email)) ?
-              <PostIcon onClick={handleDeletePost}><div className="ri-close-line"/></PostIcon> : null
-            } */}
+            {props.userEmail === email ? (
+              <PostIcon onClick={handleDeletePost}>
+                <div className="ri-close-line" />
+              </PostIcon>
+            ) : null}
             <PostIcon>
               <div className="ri-sound-module-line" />
             </PostIcon>

--- a/src/components/home/WritePost.jsx
+++ b/src/components/home/WritePost.jsx
@@ -1,18 +1,21 @@
 import * as React from 'react';
 import styled from 'styled-components';
 import { Link } from 'react-router-dom';
-import { useAuth0 } from '@auth0/auth0-react';
 import axios from 'axios';
 
+// contexts
+import { useUserInfo } from '../../contexts/UserContext.jsx';
+import { usePosts } from '../../contexts/PostsContext.jsx';
 import { usePlayer } from '../../contexts/player/playerContext';
-import { PostsContext } from '../../contexts/PostsContext.jsx';
+
+// components
 import ProfilePicture from '../ProfilePicture.jsx';
 import helper from './helperFunctions.js';
 
 const WritePost = (props) => {
-  const { user } = useAuth0();
+  const { username, email, profilePic } = useUserInfo();
+  const { posts, setPosts, isPostUpdated, setIsPostUpdated } = usePosts();
   const { songs } = usePlayer();
-  const { posts, setPosts } = React.useContext(PostsContext);
 
   const [textCharacterCount, setTextCharacterCount] = React.useState(0);
   const [uploadedAudio, setUploadedAudio] = React.useState(null);
@@ -88,10 +91,10 @@ const WritePost = (props) => {
     let tags = helper.parseTags(text);
 
     const post = {
-      profilePicture: user.picture,
+      profilePicture: profilePic,
       timePosted: new Date(Date.now()).toISOString(),
-      username: user.nickname,
-      userEmail: user.email,
+      username: username,
+      userEmail: email,
       postLikes: 0,
       isDraft: false,
       postText: text,
@@ -103,6 +106,8 @@ const WritePost = (props) => {
       tracks: [],
     };
 
+    setPosts([post].concat(posts));
+
     // axios
     //   .post(('http://54.91.250.255:1234/', post))
     //   .then((response) => {
@@ -112,14 +117,14 @@ const WritePost = (props) => {
     //     console.log(error);
     //   });
 
-    setPosts([post].concat(posts));
-    props.setIsPosted(true);
+    // eslint-disable-next-line no-extra-boolean-cast
+    setIsPostUpdated(!!!isPostUpdated);
     songs.unshift(post);
   };
 
   return (
     <WritePostWrapper>
-      <ProfilePicture username={user.nickname} profilePicture={user.picture} />
+      <ProfilePicture username={username} profilePicture={profilePic} />
       <Form onSubmit={handlePost}>
         <FlexColumn>
           <Inputs>

--- a/src/contexts/PostsContext.jsx
+++ b/src/contexts/PostsContext.jsx
@@ -1,3 +1,34 @@
 import * as React from 'react';
+import axios from 'axios';
+import dummy from '../components/home/dummy.jsx';
 
-export const PostsContext = React.createContext();
+const PostsContext = React.createContext();
+
+const PostsProvider = ({ children }) => {
+  const [isPostUpdated, setIsPostUpdated] = React.useState(false);
+  const [posts, setPosts] = React.useState(dummy);
+
+  // QUERY FOR ALL POSTS
+  React.useEffect(async () => {
+    const result = await axios('http://54.91.250.255:1234/');
+
+    setPosts(result.data);
+  }, [isPostUpdated]);
+
+  const postsContextValue = {
+    isPostUpdated,
+    setIsPostUpdated,
+    posts,
+    setPosts,
+  };
+
+  return (
+    <PostsContext.Provider value={postsContextValue}>
+      {children}
+    </PostsContext.Provider>
+  );
+};
+
+const usePosts = () => React.useContext(PostsContext);
+
+export { PostsProvider, usePosts };

--- a/src/contexts/UserContext.jsx
+++ b/src/contexts/UserContext.jsx
@@ -15,6 +15,7 @@ const UserInfoProvider = ({ children }) => {
   React.useEffect(() => {
     if (isAuthenticated) {
       const email = user.email;
+      setEmail(email);
       // axios
       //   .post('http://54.91.250.255:1234/', { email })
       //   .then((response) => {

--- a/src/contexts/player/playerContext.js
+++ b/src/contexts/player/playerContext.js
@@ -1,6 +1,5 @@
 import React, { useReducer, createContext } from 'react';
 import playerReducer from './playerReducer';
-// import { songsArr } from '../../components/audioPlayer/playlist/songs';
 import dummy from '../../components/home/dummy.jsx';
 
 const PlayerContext = createContext();

--- a/src/index.jsx
+++ b/src/index.jsx
@@ -1,16 +1,19 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
 import App from './App.jsx';
-import { PlayerProvider } from './contexts/player/playerContext';
 import { HashRouter } from 'react-router-dom';
+import { PostsProvider } from './contexts/PostsContext.jsx';
+import { PlayerProvider } from './contexts/player/playerContext';
 import Auth0ProviderWithHistory from './components/authentication/Auth0.jsx';
 
 ReactDOM.render(
   <HashRouter>
     <Auth0ProviderWithHistory>
-      <PlayerProvider>
-        <App />
-      </PlayerProvider>
+      <PostsProvider>
+        <PlayerProvider>
+          <App />
+        </PlayerProvider>
+      </PostsProvider>
     </Auth0ProviderWithHistory>
   </HashRouter>,
   document.getElementById('root')

--- a/src/pages/Home.jsx
+++ b/src/pages/Home.jsx
@@ -1,60 +1,55 @@
 import * as React from 'react';
+import axios from 'axios';
 import styled from 'styled-components';
 
-import { PostsContext } from '../contexts/PostsContext.jsx';
 import { useAuth0 } from '@auth0/auth0-react';
+import { usePosts } from '../contexts/PostsContext.jsx';
 
 import WritePost from '../components/home/WritePost.jsx';
 import Post from '../components/home/Post.jsx';
-
 import dummy from '../components/home/dummy.jsx';
-import axios from 'axios';
 
 const Home = () => {
   const { user, isAuthenticated } = useAuth0();
-  const [isPosted, setIsPosted] = React.useState(false);
-  const [posts, setPosts] = React.useState(dummy);
+  const { posts } = usePosts();
 
   React.useEffect(async () => {
     window.scroll(0, 0);
-    const result = await axios('http://54.91.250.255:1234/');
-
-    setPosts(result.data);
-  }, [isPosted]);
+  }, []);
 
   return (
-    <PostsContext.Provider value={{ posts, setPosts }}>
-      <FeedWrapper>
-        <Feed>
-          {user && (
-            <WritePost
-              username={user}
-              isPosted={isPosted}
-              setIsPosted={setIsPosted}
+    <FeedWrapper>
+      <Feed>
+        {user && (
+          <WritePost
+            username={user}
+            // isPostUpdated={isPostUpdated}
+            // setIsPostUpdated={setIsPostUpdated}
+          />
+        )}
+        {posts.map((post, i) => {
+          return (
+            <Post
+              key={i}
+              index={i}
+              postId={post.postId}
+              userEmail={post.userEmail}
+              username={post.username}
+              profilePicture={post.profilePicture}
+              projectTitle={post.projectTitle}
+              postText={post.postText}
+              projectAudioLink={post.projectAudioLink}
+              projectLength={post.projectLength}
+              projectImageLink={post.projectImageLink}
+              tags={post.tags}
+              timePosted={post.timePosted}
+              // isPostUpdated={isPostUpdated}
+              // setIsPostUpdated={setIsPostUpdated}
             />
-          )}
-          {posts.map((post, i) => {
-            return (
-              <Post
-                key={i}
-                index={i}
-                postId={post.postId}
-                userEmail={post.userEmail}
-                username={post.username}
-                profilePicture={post.profilePicture}
-                projectTitle={post.projectTitle}
-                postText={post.postText}
-                projectAudioLink={post.projectAudioLink}
-                projectLength={post.projectLength}
-                projectImageLink={post.projectImageLink}
-                tags={post.tags}
-                timePosted={post.timePosted}
-              />
-            );
-          })}
-        </Feed>
-      </FeedWrapper>
-    </PostsContext.Provider>
+          );
+        })}
+      </Feed>
+    </FeedWrapper>
   );
 };
 


### PR DESCRIPTION
Changes made
* Created a Global Post context which is the ONE place that should call posts endpoint
* This global context can be triggered to re-request the endpoint and therefore re-render from anywhere by changing the flag `setIsPostUpdated(!!!isPostUpdated);` to be the opposite of what it currently is

Example:
```
import { usePosts } from '../../contexts/PostsContext.jsx';

const WritePost = (props) => {
  const { posts, setPosts, isPostUpdated, setIsPostUpdated } = usePosts();

    const handlePost = (event) => {
      event.preventDefault();
      
      axios.post(...)
        .then((response) => {
          // do something
          setIsPostUpdated(!!!isPostUpdated); // this will trigger a re-render of the global post state,
                                              // showing the new post in the updated feed
        })
    }

return (...)
```

@rita0927 will need to update the playerContext to subscribe to the posts, and update when it re-renders